### PR TITLE
Add dump_to steps at the end of the kns_documentcommitteesession pipeline

### DIFF
--- a/committees/knesset.source-spec.yaml
+++ b/committees/knesset.source-spec.yaml
@@ -261,7 +261,14 @@ kns_documentcommitteesession:
       download-from-path: ../data/committees/download_document_committee_session/
       # download-from-remote-storage: https://storage.googleapis.com/knesset-data-pipelines/data/committees/download_document_committee_session/
       out-path: ../data/committees/meeting_protocols_parts
-
+  - run: knesset.dump_to_path
+    parameters:
+      out-path: ../data/committees/kns_documentcommitteesession
+  - run: knesset.dump_to_sql
+    parameters:
+      tables:
+        committees_kns_documentcommitteesession:
+          resource-name: kns_documentcommitteesession
 
 # moved to Airflow
 #background_material_titles:


### PR DESCRIPTION
I'm not entirely sure that this is the best solution here - perhaps the correct way would be to restore this pipeline as a "knesset dataservice", as it was before commit ffc6e20a14962d1bdf902c10cee21c7b564a2b2e 

@OriHoch