### PR TITLE
Add a table with names in english for any available mk_idividual_id

### DIFF
--- a/airflow/knesset_data_pipelines/cli.py
+++ b/airflow/knesset_data_pipelines/cli.py
@@ -16,6 +16,7 @@ def main(load_dotenv):
 for module_name, function_name in [
     ('.google_drive_upload.cli', 'google_drive_upload'),
     ('.committees.cli', 'committees'),
+    ( '.members_eng.cli', 'members_eng'),
 ]:
     main.add_command(getattr(importlib.import_module(module_name, __package__), function_name))
 

--- a/airflow/knesset_data_pipelines/committees/common.py
+++ b/airflow/knesset_data_pipelines/committees/common.py
@@ -1,5 +1,5 @@
 from .. import db
-
+from sqlalchemy import text
 
 def get_committee_parents(committee, committees):
     parent_committee_id = committee['parent_committee_id']
@@ -21,14 +21,14 @@ def get_committees_tree():
                     'parent_committee_id': row.parent_committee_id,
                     'name': row.name,
                     'category_desc': row.category_desc,
-                } for row in conn.execute('''
+                } for row in conn.execute(text('''
                     select
                         "CommitteeID" as committee_id,
                         "ParentCommitteeID" as parent_committee_id,
                         "Name" as name,
                         "CategoryDesc" as category_desc
                     from committees_kns_committee
-                ''')
+                '''))
             }
     for committee in committees.values():
         committee['parent_committee_ids'] = get_committee_parents(committee, committees)

--- a/airflow/knesset_data_pipelines/members_eng/cli.py
+++ b/airflow/knesset_data_pipelines/members_eng/cli.py
@@ -6,9 +6,9 @@ def members_eng():
     pass
 
 @members_eng.command()
+@click.option('--slow', is_flag=True)
 def members_eng(**kwargs):
     '''Create a table of knesset member names in english
     '''
     from .members_eng import main
-    print("running main")
     main(**kwargs)

--- a/airflow/knesset_data_pipelines/members_eng/cli.py
+++ b/airflow/knesset_data_pipelines/members_eng/cli.py
@@ -1,0 +1,14 @@
+import click
+
+
+@click.group()
+def members_eng():
+    pass
+
+@members_eng.command()
+def members_eng(**kwargs):
+    '''Create a table of knesset member names in english
+    '''
+    from .members_eng import main
+    print("running main")
+    main(**kwargs)

--- a/airflow/knesset_data_pipelines/members_eng/members_eng.py
+++ b/airflow/knesset_data_pipelines/members_eng/members_eng.py
@@ -1,6 +1,7 @@
 import os
-import traceback
 from textwrap import dedent
+import traceback
+import json
 
 import dataflows as DF
 from pyquery import PyQuery as pq
@@ -8,37 +9,46 @@ from pyquery import PyQuery as pq
 from .. import db, config
 from ..get_retry_response_content import get_retry_response_content
 
-URL = "https://main.knesset.gov.il/en/MK/APPS/mk/mk-personal-details"
+def get_members_id():
+    """Return an iterable of all valid mk_individual_id
+    """
+    return range(1, 6000)
 
 def iterate_members():
-    for member_id in range(1, 121):
+    for member_id in get_members_id():
+        URL = f"https://knesset.gov.il/WebSiteApi/knessetapi/MKs/GetMkdetailsHeader?mkId={member_id}&languageKey=en"
+        print(f"getting {URL}")
         try:
             content = get_retry_response_content(
-                f"{URL}/{member_id}", None, None, None, retry_num=1,
+                URL, None, None, None, retry_num=1,
                 num_retries=10, seconds_between_retries=10,
                 skip_not_found_errors=True)
         except Exception:
-            treaceback.print_exc()
-            content = None
-            print(f'failed to get {URL}/{member_id}')
+            traceback.print_exc()
+            print(f'failed to get {URL}')
         else:
-            page = pq(content)
-            # Hmm, the page is rendered by javascript, so the get_retry_response is empty
-            import pdb;pdb.set_trace()
+            data = json.loads(content)
+            name = data.get('Name', '')
+            if not name:
+                continue
+            yield {
+                "NameEng": name,
+                "mk_individual_id": member_id,
+            }
 
 def main():
     table_name = 'member_english_names'
     temp_table_name = f'__temp__{table_name}'
     DF.Flow(
         iterate_members(),
-        DF.update_resource(-1, name='member_english_name', path='member_english_name.csv'),
-        DF.dump_to_path(os.path.join(config.KNESSET_PIPELINES_DATA_PATH, 'members', 'memger_english_names')),
+        DF.update_resource(-1, name='member_english_names', path='member_english_names.csv'),
+        DF.dump_to_path(os.path.join(config.KNESSET_PIPELINES_DATA_PATH, 'members', 'member_english_names')),
         DF.dump_to_sql(
             {temp_table_name: {'resource-name': 'member_english_names'}},
             db.get_db_engine(),
             batch_size=100000,
         ),
-    ).process
+    ).process()
     with db.get_db_engine().connect() as conn:
         with conn.begin():
             conn.execute(dedent(f'''

--- a/airflow/knesset_data_pipelines/members_eng/members_eng.py
+++ b/airflow/knesset_data_pipelines/members_eng/members_eng.py
@@ -1,0 +1,48 @@
+import os
+import traceback
+from textwrap import dedent
+
+import dataflows as DF
+from pyquery import PyQuery as pq
+
+from .. import db, config
+from ..get_retry_response_content import get_retry_response_content
+
+URL = "https://main.knesset.gov.il/en/MK/APPS/mk/mk-personal-details"
+
+def iterate_members():
+    for member_id in range(1, 121):
+        try:
+            content = get_retry_response_content(
+                f"{URL}/{member_id}", None, None, None, retry_num=1,
+                num_retries=10, seconds_between_retries=10,
+                skip_not_found_errors=True)
+        except Exception:
+            treaceback.print_exc()
+            content = None
+            print(f'failed to get {URL}/{member_id}')
+        else:
+            page = pq(content)
+            # Hmm, the page is rendered by javascript, so the get_retry_response is empty
+            import pdb;pdb.set_trace()
+
+def main():
+    table_name = 'member_english_names'
+    temp_table_name = f'__temp__{table_name}'
+    DF.Flow(
+        iterate_members(),
+        DF.update_resource(-1, name='member_english_name', path='member_english_name.csv'),
+        DF.dump_to_path(os.path.join(config.KNESSET_PIPELINES_DATA_PATH, 'members', 'memger_english_names')),
+        DF.dump_to_sql(
+            {temp_table_name: {'resource-name': 'member_english_names'}},
+            db.get_db_engine(),
+            batch_size=100000,
+        ),
+    ).process
+    with db.get_db_engine().connect() as conn:
+        with conn.begin():
+            conn.execute(dedent(f'''
+                    drop table if exists {table_name};
+                    alter table {temp_table_name} rename to {table_name};
+                '''))
+    

--- a/airflow/knesset_data_pipelines/members_eng/members_eng.py
+++ b/airflow/knesset_data_pipelines/members_eng/members_eng.py
@@ -1,4 +1,5 @@
 import os
+import requests
 from textwrap import dedent
 import time
 import traceback
@@ -13,7 +14,11 @@ from ..get_retry_response_content import get_retry_response_content
 def get_members_id():
     """Return an iterable of all valid mk_individual_id
     """
-    return range(1, 1000)
+    url = "https://backend.oknesset.org/members"
+    for item in requests.get(f"{url}?is_current=true").json():
+        yield item['mk_individual_id']
+    for item in requests.get(f"{url}?is_current=false").json():
+        yield item['mk_individual_id']
 
 def iterate_members(slow: bool = False):
     delay=10


### PR DESCRIPTION
Towards #220.

Add a command line option to fill a table and create a CSV with the names in english, taken from `https://knesset.gov.il/WebSiteApi/knessetapi/MKs/GetMkdetailsHeader?mkId={member_id}&languageKey=en`

Not all the ids have a matching english page.