### PR TITLE
docs: update README to reflect Airflow-based architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,130 +1,74 @@
-# Knesset data pipelines
+# Knesset Data Pipelines
 
-Data processing pipelines for loading, processing and visualizing data about the Knesset
+Data processing pipelines for loading, processing and visualizing data about the Israeli Knesset (Parliament).
 
-We are in the process of migrating to airflow, see [airflow/README.md](airflow/README.md) for details.
+The project uses [Apache Airflow](https://airflow.apache.org/) for orchestration and [DataFlows](https://github.com/datahq/dataflows) for data processing.
 
-Uses the [datapackage pipelines](https://github.com/frictionlessdata/datapackage-pipelines) and [DataFlows](https://github.com/datahq/dataflows) frameworks.
+## Quickstart
 
-## Quickstart for data science
+Prerequisites:
+* Python 3.8+ with [uv](https://pypi.org/project/uv/)
+* Docker Compose
 
-Follow this method to get started quickly with exploration, processing and testing of the knesset data.
-
-### Running using Docker
-
-Docker is required to run the notebooks to provide a consistent environment.
-
-Install Docker for [Windows](https://store.docker.com/editions/community/docker-ce-desktop-windows),
-[Mac](https://store.docker.com/editions/community/docker-ce-desktop-mac) or [Linux](https://docs.docker.com/install/)
-
-Pull the latest Docker image
-
-```
-docker pull ghcr.io/hasadna/knesset-data-pipelines/knesset-data-pipelines-legacy
+```bash
+cd airflow
+uv sync                              # Install dependencies
+docker compose up -d db              # Start PostgreSQL
+uv run knesset-data-pipelines --help  # Run the CLI
 ```
 
-#### Run Jupyter Lab
+See [airflow/README.md](airflow/README.md) for full development setup including local Airflow and Docker Compose options.
 
-Create a directory which will be shared between the host PC and the container:
-
-```
-sudo mkdir -p /opt/knesset-data-pipelines
-```
-
-Start the Jupyter lab server:
+## Project Structure
 
 ```
-docker run -it -p 8888:8888 --entrypoint jupyter \
-           -v /opt/knesset-data-pipelines:/pipelines \
-           ghcr.io/hasadna/knesset-data-pipelines/knesset-data-pipelines-legacy lab --allow-root --ip 0.0.0.0 --no-browser \
-                --NotebookApp.token= --NotebookApp.custom_display_url=http://localhost:8888/
+airflow/                          # Main project code (Airflow-based)
+├── dags/                         # Airflow DAG definitions
+├── knesset_data_pipelines/       # Core Python module
+│   ├── cli.py                    # CLI entry point
+│   ├── run_pipeline.py           # Pipeline execution engine
+│   ├── kns_odata.py              # Knesset OData API client
+│   └── committees/               # Committee-specific processing
+├── pipelines/                    # Pipeline configurations (YAML)
+├── compose.yaml                  # Docker Compose for local dev
+└── pyproject.toml                # Dependencies
+
+datapackage_pipelines_knesset/    # Legacy DPP framework (deprecated)
 ```
 
-Access the server at http://localhost:8888/
+## Data Sources
 
-Open a terminal inside the Jupyter Lab web-ui, and clone the knesset-data-pipelines project:
-
-```
-git clone https://github.com/hasadna/knesset-data-pipelines.git .
-```
-
-You should now see the project files on the left sidebar.
-
-Access the `jupyter-notebooks` directory and open one of the available notebooks.
-
-You can now add or make modifications to the notebooks, then open a pull request with your changes.
-
-You can also modify the pipelines code from the host machine and it will be reflected in the notebook environment.
-
-#### Running from Local copy of knesset-data-pipelines
-
-From your local PC, clone the repository into ./knesset-data-pipelines:
-
-```
-git clone https://github.com/hasadna/knesset-data-pipelines.git .
-```
-
-Change directory:
-
-```
-cd knesset-data-pipelines
-```
-
-Run with Docker, mounting the local directory
-
-```
-docker run -it -p 8888:8888 --entrypoint jupyter \
-           -v `pwd`:/pipelines \
-           ghcr.io/hasadna/knesset-data-pipelines/knesset-data-pipelines-legacy lab --allow-root --ip 0.0.0.0 --no-browser \
-                --NotebookApp.token= --NotebookApp.custom_display_url=http://localhost:8888/
-```
-
-When running using this setup, you might have permission problems, fix it giving yourself ownership:
-
-```
-sudo chown -R $USER . 
-```
-
-### Running locally without Docker
-
-Following instructions were tested with Ubuntu 18.04
-
-Install system dependencies:
-
-```
-sudo apt-get install python3.6 python3.6-dev build-essential libxml2-dev libxslt1-dev libleveldb1v5 libleveldb-dev \
-                     python3-pip bash jq git openssl antiword python3-venv
-```
-
-Install Python dependencies:
-
-```
-python3.6 -m venv env
-source env/bin/activate
-pip install 'https://github.com/OriHoch/datapackage-pipelines/archive/1.7.1-oh-2.zip#egg=datapackage-pipelines[speedup]'
-pip install wheel
-pip install psycopg2-binary knesset-data requests[socks] botocore boto3 python-dotenv google-cloud-storage sh
-pip install datapackage-pipelines-metrics psutil crcmod jsonpickle tika kvfile pyquery dataflows==0.0.14 pymongo \
-            tabulate jupyter jupyterlab
-pip install -e .
-```
-
-Start environment (these steps are required each time before starting to run pipelines):
-
-```
-source env/bin/activate
-export KNESSET_PIPELINES_DATA_PATH=`pwd`/data
-```
-
-Now you can run pipelines with `dpp` or start the notebook server with `jupyter lab`
+The pipelines ingest data from the [Knesset OData APIs](http://main.knesset.gov.il/Activity/Info/Pages/Databases.aspx):
+* **Bills & Laws** — Legislation data
+* **Members** — Knesset member details and positions
+* **Committees** — Meeting schedules, protocols and documents
+* **Votes** — Parliamentary voting records
+* **Lobbyists** — Registered lobbyist data
 
 ## Contributing
 
-Looking to contribute? check out the [Help Wanted Issues](https://github.com/hasadna/knesset-data-pipelines/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) or the [Noob Friendly Issues](https://github.com/hasadna/knesset-data-pipelines/issues?q=is%3Aissue+is%3Aopen+label%3A%22noob+friendly%22) for some ideas.
+Looking to contribute? Check out the [open issues](https://github.com/hasadna/knesset-data-pipelines/issues) or the [Help Wanted](https://github.com/hasadna/knesset-data-pipelines/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) and [Noob Friendly](https://github.com/hasadna/knesset-data-pipelines/issues?q=is%3Aissue+is%3Aopen+label%3A%22noob+friendly%22) labels.
 
-Useful resources for getting acquainted:
-* [DPP](https://github.com/frictionlessdata/datapackage-pipelines) documentation
-* [Code](https://github.com/OriHoch/knesset-data-k8s) for the periodic execution component
-* [Info](http://main.knesset.gov.il/Activity/Info/Pages/Databases.aspx) on available data from the Knesset site
-* Living [document](https://docs.google.com/document/d/1eeQRrpGYuEJKAAtShPbjFn6i2f_UmQgg1caMTEs93ic/edit) with short list of ongoing project activities
+Useful resources:
+* [Airflow documentation](https://airflow.apache.org/docs/)
+* [DataFlows documentation](https://github.com/datahq/dataflows)
+* [Knesset databases info](http://main.knesset.gov.il/Activity/Info/Pages/Databases.aspx)
+* [Project activities document](https://docs.google.com/document/d/1eeQRrpGYuEJKAAtShPbjFn6i2f_UmQgg1caMTEs93ic/edit)
 
+<details>
+<summary>Legacy setup (deprecated datapackage-pipelines)</summary>
+
+The project was previously built on [datapackage-pipelines](https://github.com/frictionlessdata/datapackage-pipelines). The legacy code remains in `datapackage_pipelines_knesset/` but is no longer actively maintained. Most pipelines have been migrated to Airflow.
+
+To run the legacy Docker image:
+
+```bash
+docker pull ghcr.io/hasadna/knesset-data-pipelines/knesset-data-pipelines-legacy
+docker run -it -p 8888:8888 --entrypoint jupyter \
+           -v $(pwd):/pipelines \
+           ghcr.io/hasadna/knesset-data-pipelines/knesset-data-pipelines-legacy \
+           lab --allow-root --ip 0.0.0.0 --no-browser \
+           --NotebookApp.token= --NotebookApp.custom_display_url=http://localhost:8888/
+```
+
+</details>


### PR DESCRIPTION
## Summary
- Rewrote the root README to lead with the current Airflow/uv-based quickstart instead of the deprecated datapackage-pipelines setup
- Added a project structure overview showing the `airflow/` directory as the main codebase
- Listed the data sources the pipelines process (bills, members, committees, votes, lobbyists)
- Moved legacy DPP setup instructions into a collapsible `<details>` block to preserve them without confusing new contributors
- Updated contributing links and resources to current tooling

Closes #229

## Test plan
- [x] Verify quickstart commands match `airflow/README.md`
- [x] Verify project structure matches actual directory layout
- [ ] Review rendered markdown on GitHub for formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)